### PR TITLE
fix: remove dead link

### DIFF
--- a/docs/Report/index.md
+++ b/docs/Report/index.md
@@ -16,7 +16,3 @@ This report documents the development of the KEYLA-TTT project, covering all asp
 - **[DevOps](./DevOps)** - CI/CD pipeline and infrastructure
 - **[Technologies](./Technologies)** - Technology stack and tools used
 - **[Conclusion](./Conclusion)** - Project summary and lessons learned
-
-## Resources
-
-Additional resources including diagrams and documentation can be found in the [Resources](./Resources/) directory. 


### PR DESCRIPTION
This pull request makes a minor update to the project documentation by removing the "Resources" section from the main report index. This change simplifies the index and removes the reference to the additional resources directory.